### PR TITLE
Improve cross mapping UX and fix toast, navigation, and import workflows

### DIFF
--- a/src/components/dialogs/PriceListImportDialog.tsx
+++ b/src/components/dialogs/PriceListImportDialog.tsx
@@ -2,14 +2,14 @@ import { useState, useRef } from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Badge } from '@/components/ui/badge';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Progress } from '@/components/ui/progress';
 import { useToast } from '@/hooks/use-toast';
 import { supabase } from '@/integrations/supabase/client';
-import { Upload, FileText, AlertTriangle, CheckCircle, X } from 'lucide-react';
+import { downloadPriceListTemplate } from '@/lib/excel-utils';
+import { Upload, FileText, AlertTriangle, CheckCircle } from 'lucide-react';
 import * as XLSX from 'xlsx';
 
 interface ImportRow {
@@ -22,6 +22,7 @@ interface ImportRow {
   rowIndex: number;
   errors: string[];
   productFound?: boolean;
+  productId?: string;
   baseCost?: number;
   marginPercent?: number;
   marginEuro?: number;
@@ -44,54 +45,6 @@ export const PriceListImportDialog = ({ open, onOpenChange, onSuccess }: PriceLi
   const fileInputRef = useRef<HTMLInputElement>(null);
   const { toast } = useToast();
 
-  const downloadTemplate = () => {
-    const templateData = [
-      {
-        product_code: 'SP-3142',
-        customer_name: 'Marina SpA',
-        list_name: 'Listino 2024',
-        list_version: 'v1.0',
-        list_identifier: '2024-001',
-        unit_price: 85.50
-      },
-      {
-        product_code: 'SP-2847',
-        customer_name: 'Marina SpA', 
-        list_name: 'Listino 2024',
-        list_version: 'v1.0',
-        list_identifier: '2024-001',
-        unit_price: 72.30
-      }
-    ];
-
-    const wb = XLSX.utils.book_new();
-    const ws = XLSX.utils.json_to_sheet(templateData);
-    
-    // Set column widths
-    ws['!cols'] = [
-      { wch: 15 }, // product_code
-      { wch: 20 }, // customer_name
-      { wch: 20 }, // list_name
-      { wch: 12 }, // list_version
-      { wch: 15 }, // list_identifier
-      { wch: 12 }  // unit_price
-    ];
-
-    XLSX.utils.book_append_sheet(wb, ws, 'PriceListTemplate');
-    
-    const buffer = XLSX.write(wb, { type: 'array', bookType: 'xlsx' });
-    const blob = new Blob([buffer], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
-    const url = URL.createObjectURL(blob);
-    
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = `Template_Listini_${new Date().toISOString().slice(0, 10)}.xlsx`;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    URL.revokeObjectURL(url);
-  };
-
   const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
     const selectedFile = event.target.files?.[0];
     if (selectedFile) {
@@ -108,24 +61,38 @@ export const PriceListImportDialog = ({ open, onOpenChange, onSuccess }: PriceLi
       const workbook = XLSX.read(arrayBuffer);
       const sheetName = workbook.SheetNames[0];
       const worksheet = workbook.Sheets[sheetName];
-      const jsonData = XLSX.utils.sheet_to_json(worksheet) as any[];
+      const jsonData = XLSX.utils.sheet_to_json<Record<string, unknown>>(worksheet);
 
-      const processedData: ImportRow[] = [];
+      const toTrimmedString = (value: unknown) => {
+        if (typeof value === 'string' || typeof value === 'number') {
+          return String(value).trim();
+        }
+        return '';
+      };
 
-      for (let i = 0; i < jsonData.length; i++) {
-        const row = jsonData[i];
+      const toNumber = (value: unknown) => {
+        if (typeof value === 'number') {
+          return value;
+        }
+        if (typeof value === 'string') {
+          const parsed = parseFloat(value);
+          return Number.isFinite(parsed) ? parsed : 0;
+        }
+        return 0;
+      };
+
+      const processedData: ImportRow[] = jsonData.map((row, index) => {
         const importRow: ImportRow = {
-          product_code: row.product_code?.toString()?.trim() || '',
-          customer_name: row.customer_name?.toString()?.trim() || '',
-          list_name: row.list_name?.toString()?.trim() || '',
-          list_version: row.list_version?.toString()?.trim() || '',
-          list_identifier: row.list_identifier?.toString()?.trim() || '',
-          unit_price: parseFloat(row.unit_price) || 0,
-          rowIndex: i + 2, // +2 because Excel starts at 1 and we have headers
+          product_code: toTrimmedString(row['product_code']),
+          customer_name: toTrimmedString(row['customer_name']),
+          list_name: toTrimmedString(row['list_name']),
+          list_version: toTrimmedString(row['list_version']),
+          list_identifier: toTrimmedString(row['list_identifier']),
+          unit_price: toNumber(row['unit_price']),
+          rowIndex: index + 2,
           errors: []
         };
 
-        // Validation
         if (!importRow.product_code) {
           importRow.errors.push('Codice prodotto mancante');
         }
@@ -139,22 +106,39 @@ export const PriceListImportDialog = ({ open, onOpenChange, onSuccess }: PriceLi
           importRow.errors.push('Prezzo unitario non valido');
         }
 
-        // Check if product exists and get base cost
-        if (importRow.product_code) {
-          const { data: productData } = await supabase
-            .from('propellers')
-            .select('id, model, base_cost')
-            .eq('model', importRow.product_code)
-            .maybeSingle();
+        return importRow;
+      });
 
-          if (productData?.id) {
+      const productCodes = Array.from(new Set(processedData.map(row => row.product_code).filter(Boolean)));
+      const productLookup = new Map<string, { id: string; base_cost: number | null }>();
+
+      if (productCodes.length > 0) {
+        const { data: productsData, error: productsError } = await supabase
+          .from('propellers')
+          .select('id, model, base_cost')
+          .in('model', productCodes);
+
+        if (productsError) throw productsError;
+
+        (productsData ?? []).forEach(product => {
+          productLookup.set(product.model, {
+            id: product.id,
+            base_cost: product.base_cost,
+          });
+        });
+      }
+
+      const enrichedData = processedData.map(importRow => {
+        if (importRow.product_code) {
+          const product = productLookup.get(importRow.product_code);
+          if (product) {
             importRow.productFound = true;
-            importRow.baseCost = productData.base_cost || 0;
-            
-            // Calculate margins only if base_cost exists and unit_price is valid
-            if (importRow.unit_price > 0 && productData.base_cost !== null) {
-              importRow.marginEuro = importRow.unit_price - productData.base_cost;
-              importRow.marginPercent = ((importRow.unit_price - productData.base_cost) / importRow.unit_price) * 100;
+            importRow.productId = product.id;
+            importRow.baseCost = product.base_cost ?? 0;
+
+            if (importRow.unit_price > 0 && product.base_cost !== null) {
+              importRow.marginEuro = importRow.unit_price - product.base_cost;
+              importRow.marginPercent = ((importRow.unit_price - product.base_cost) / importRow.unit_price) * 100;
             }
           } else {
             importRow.productFound = false;
@@ -162,17 +146,17 @@ export const PriceListImportDialog = ({ open, onOpenChange, onSuccess }: PriceLi
           }
         }
 
-        processedData.push(importRow);
-      }
+        return importRow;
+      });
 
-      setImportData(processedData);
+      setImportData(enrichedData);
       setStep('preview');
     } catch (error) {
       console.error('Error processing file:', error);
       toast({
-        title: "Errore",
+        title: 'Errore',
         description: "Errore durante la lettura del file Excel",
-        variant: "destructive"
+        variant: 'destructive'
       });
     } finally {
       setProcessing(false);
@@ -180,23 +164,24 @@ export const PriceListImportDialog = ({ open, onOpenChange, onSuccess }: PriceLi
   };
 
   const executeImport = async () => {
-    const validRows = importData.filter(row => row.errors.length === 0 && row.productFound);
+    const validRows = importData.filter(row => row.errors.length === 0 && row.productFound && row.productId);
     if (validRows.length === 0) {
       toast({
-        title: "Errore",
-        description: "Nessuna riga valida da importare",
-        variant: "destructive"
+        title: 'Errore',
+        description: 'Nessuna riga valida da importare',
+        variant: 'destructive'
       });
       return;
     }
 
     setImporting(true);
     setStep('importing');
+    setProgress(0);
+
     let successCount = 0;
     let errorCount = 0;
 
     try {
-      // Group by customer and list
       const groupedData = validRows.reduce((acc, row) => {
         const key = `${row.customer_name}_${row.list_name}_${row.list_identifier}`;
         if (!acc[key]) {
@@ -205,110 +190,131 @@ export const PriceListImportDialog = ({ open, onOpenChange, onSuccess }: PriceLi
             list_name: row.list_name,
             list_version: row.list_version,
             list_identifier: row.list_identifier,
-            items: []
+            items: [] as ImportRow[]
           };
         }
         acc[key].items.push(row);
         return acc;
-      }, {} as any);
+      }, {} as Record<string, { customer_name: string; list_name: string; list_version: string; list_identifier: string; items: ImportRow[] }>);
 
-      const groups = Object.values(groupedData) as any[];
-      
+      const groups = Object.values(groupedData);
+
+      const customerNames = Array.from(new Set(groups.map(group => group.customer_name)));
+      const customerMap = new Map<string, string>();
+
+      if (customerNames.length > 0) {
+        const { data: existingCustomers, error: existingCustomersError } = await supabase
+          .from('customers')
+          .select('id, name')
+          .in('name', customerNames);
+
+        if (existingCustomersError) throw existingCustomersError;
+
+        (existingCustomers ?? []).forEach(customer => {
+          customerMap.set(customer.name, customer.id);
+        });
+      }
+
+      const missingCustomers = customerNames.filter(name => !customerMap.has(name));
+      if (missingCustomers.length > 0) {
+        const { data: newCustomers, error: insertCustomersError } = await supabase
+          .from('customers')
+          .insert(missingCustomers.map(name => ({ name })))
+          .select('id, name');
+
+        if (insertCustomersError) throw insertCustomersError;
+
+        (newCustomers ?? []).forEach(customer => {
+          customerMap.set(customer.name, customer.id);
+        });
+      }
+
       for (let i = 0; i < groups.length; i++) {
         const group = groups[i];
-        setProgress((i / groups.length) * 100);
+        setProgress(Math.round((i / groups.length) * 100));
+
+        const customerId = customerMap.get(group.customer_name);
+        if (!customerId) {
+          errorCount += group.items.length;
+          continue;
+        }
 
         try {
-          // Find or create customer
-          let customerId = '';
-          const { data: existingCustomer } = await supabase
-            .from('customers')
-            .select('id')
-            .eq('name', group.customer_name)
-            .maybeSingle();
+          const listName = group.list_version
+            ? `${group.list_name} ${group.list_version}`.trim()
+            : group.list_name;
 
-          if (existingCustomer) {
-            customerId = existingCustomer.id;
-          } else {
-            const { data: newCustomer, error: customerError } = await supabase
-              .from('customers')
-              .insert([{ name: group.customer_name }])
-              .select('id')
-              .single();
-
-            if (customerError) throw customerError;
-            customerId = newCustomer.id;
-          }
-
-          // Create price list
           const { data: priceList, error: priceListError } = await supabase
             .from('price_lists')
             .insert([{
-              list_name: `${group.list_name} ${group.list_version}`,
+              list_name: listName,
               customer_id: customerId,
               currency: 'EUR',
               valid_from: new Date().toISOString().split('T')[0],
-              notes: `Importato da Excel - ${group.list_identifier}`
+              notes: group.list_identifier
+                ? `Importato da Excel - ${group.list_identifier}`
+                : 'Importato da Excel'
             }])
             .select('id')
             .single();
 
-          if (priceListError) throw priceListError;
-
-          // Insert price list items
-          for (const item of group.items) {
-            const { data: product } = await supabase
-              .from('propellers')
-              .select('id')
-              .eq('model', item.product_code)
-              .single();
-
-            if (product) {
-              const { error: itemError } = await supabase
-                .from('price_list_items')
-                .insert([{
-                  price_list_id: priceList.id,
-                  propeller_id: product.id,
-                  unit_price: item.unit_price,
-                  margin_percent: item.marginPercent,
-                  margin_euro: item.marginEuro,
-                  pricing_method: 'margin_percent'
-                }]);
-
-              if (itemError) {
-                console.error('Error inserting item:', itemError);
-                errorCount++;
-              } else {
-                successCount++;
-              }
-            }
+          if (priceListError || !priceList) {
+            errorCount += group.items.length;
+            continue;
           }
-        } catch (error) {
-          console.error('Error importing group:', error);
+
+          const itemsPayload = group.items
+            .filter(item => item.productId)
+            .map(item => ({
+              price_list_id: priceList.id,
+              propeller_id: item.productId!,
+              unit_price: item.unit_price,
+              margin_percent: item.marginPercent ?? null,
+              margin_euro: item.marginEuro ?? null,
+              pricing_method: item.marginPercent !== undefined ? 'margin_percent' : 'target_price'
+            }));
+
+          if (itemsPayload.length === 0) {
+            continue;
+          }
+
+          const { error: insertItemsError } = await supabase
+            .from('price_list_items')
+            .insert(itemsPayload);
+
+          if (insertItemsError) {
+            console.error('Error inserting items:', insertItemsError);
+            errorCount += itemsPayload.length;
+          } else {
+            successCount += itemsPayload.length;
+          }
+        } catch (groupError) {
+          console.error('Error importing group:', groupError);
           errorCount += group.items.length;
         }
       }
 
+      setProgress(100);
       setImportResults({ success: successCount, errors: errorCount });
       setStep('complete');
-      
+
       if (successCount > 0) {
         toast({
-          title: "Import completato",
+          title: 'Import completato',
           description: `${successCount} prodotti importati con successo${errorCount > 0 ? `, ${errorCount} errori` : ''}`
         });
         onSuccess();
       }
-    } catch (error) {
-      console.error('Error during import:', error);
-      toast({
-        title: "Errore",
-        description: "Errore durante l'importazione",
-        variant: "destructive"
-      });
+   } catch (error) {
+     console.error('Error during import:', error);
+      setStep('preview');
+     toast({
+       title: 'Errore',
+       description: "Errore durante l'importazione",
+       variant: 'destructive'
+     });
     } finally {
       setImporting(false);
-      setProgress(100);
     }
   };
 
@@ -357,7 +363,7 @@ export const PriceListImportDialog = ({ open, onOpenChange, onSuccess }: PriceLi
                 />
                 <div className="flex gap-2 justify-center">
                   <Button
-                    onClick={downloadTemplate}
+                    onClick={downloadPriceListTemplate}
                     variant="outline"
                     size="sm"
                   >
@@ -388,7 +394,7 @@ export const PriceListImportDialog = ({ open, onOpenChange, onSuccess }: PriceLi
                 <Button variant="outline" onClick={() => setStep('upload')}>
                   Indietro
                 </Button>
-                <Button 
+                <Button
                   onClick={executeImport}
                   disabled={importData.filter(row => row.errors.length === 0).length === 0}
                 >
@@ -449,6 +455,15 @@ export const PriceListImportDialog = ({ open, onOpenChange, onSuccess }: PriceLi
               <p className="text-sm text-muted-foreground text-center">
                 Mostrate prime 50 righe di {importData.length}
               </p>
+            )}
+
+            {importData.some(row => row.errors.length > 0) && (
+              <Alert variant="destructive">
+                <AlertTriangle className="h-4 w-4" />
+                <AlertDescription>
+                  Correggi gli errori evidenziati nel file e ricarica il documento per includere tutte le righe.
+                </AlertDescription>
+              </Alert>
             )}
           </div>
         )}

--- a/src/components/ui/search-filter-card.tsx
+++ b/src/components/ui/search-filter-card.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactNode, forwardRef } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Search } from 'lucide-react';
@@ -10,12 +10,12 @@ interface SearchFilterCardProps {
   children?: ReactNode;
 }
 
-export const SearchFilterCard = ({ 
-  searchTerm, 
-  onSearchChange, 
+const SearchFilterCard = forwardRef<HTMLInputElement, SearchFilterCardProps>(({ 
+  searchTerm,
+  onSearchChange,
   placeholder,
-  children 
-}: SearchFilterCardProps) => {
+  children
+}, ref) => {
   return (
     <Card className="card-elevated">
       <CardHeader>
@@ -27,6 +27,7 @@ export const SearchFilterCard = ({
             <div className="relative">
               <Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
               <Input
+                ref={ref}
                 placeholder={placeholder}
                 value={searchTerm}
                 onChange={(e) => onSearchChange(e.target.value)}
@@ -43,4 +44,8 @@ export const SearchFilterCard = ({
       </CardContent>
     </Card>
   );
-};
+});
+
+SearchFilterCard.displayName = 'SearchFilterCard';
+
+export { SearchFilterCard };

--- a/src/contexts/SidebarContext.tsx
+++ b/src/contexts/SidebarContext.tsx
@@ -20,16 +20,26 @@ interface SidebarProviderProps {
   children: ReactNode;
 }
 
+const isBrowser = typeof window !== 'undefined';
+
 export const SidebarProvider = ({ children }: SidebarProviderProps) => {
   // Initialize from localStorage, default to false (expanded)
   const [collapsed, setCollapsedState] = useState(() => {
-    const saved = localStorage.getItem('sidebar-collapsed');
+    if (!isBrowser) {
+      return false;
+    }
+
+    const saved = window.localStorage.getItem('sidebar-collapsed');
     return saved ? JSON.parse(saved) : false;
   });
 
   // Persist to localStorage when state changes
   useEffect(() => {
-    localStorage.setItem('sidebar-collapsed', JSON.stringify(collapsed));
+    if (!isBrowser) {
+      return;
+    }
+
+    window.localStorage.setItem('sidebar-collapsed', JSON.stringify(collapsed));
   }, [collapsed]);
 
   const setCollapsed = (value: boolean) => {

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -167,14 +167,17 @@ function useToast() {
   const [state, setState] = React.useState<State>(memoryState);
 
   React.useEffect(() => {
-    listeners.push(setState);
+    if (!listeners.includes(setState)) {
+      listeners.push(setState);
+    }
+
     return () => {
       const index = listeners.indexOf(setState);
       if (index > -1) {
         listeners.splice(index, 1);
       }
     };
-  }, [state]);
+  }, []);
 
   return {
     ...state,

--- a/src/hooks/useCrossMappings.ts
+++ b/src/hooks/useCrossMappings.ts
@@ -1,0 +1,219 @@
+import { useEffect, useMemo, useState } from 'react';
+import { supabase } from '@/integrations/supabase/client';
+import type { Database } from '@/integrations/supabase/types';
+
+export type CrossReferenceKind = 'oem' | 'supersession' | 'application' | 'other';
+
+interface CrossReferenceEntry {
+  id: string;
+  propellerId?: string;
+  cefCode: string;
+  referenceCode: string;
+  context?: string | null;
+  notes?: string | null;
+  rawType?: string | null;
+  type: CrossReferenceKind;
+  createdAt?: string | null;
+}
+
+interface OemManufacturerGroup {
+  name: string;
+  codes: string[];
+  notes: string[];
+}
+
+export interface OemInterchange {
+  cefCode: string;
+  propellerId?: string;
+  manufacturers: OemManufacturerGroup[];
+}
+
+export interface SupersessionChainEntry {
+  cefCode: string;
+  propellerId?: string;
+  chain: Array<{ code: string; note?: string | null; createdAt?: string | null }>;
+}
+
+export interface ApplicationGuideEntry {
+  cefCode: string;
+  propellerId?: string;
+  applications: Array<{ model: string; referenceCode: string; note?: string | null }>;
+}
+
+const normalizeReferenceType = (value: string | null): CrossReferenceKind => {
+  const normalized = value?.toLowerCase() ?? '';
+  if (!normalized) {
+    return 'other';
+  }
+
+  if (['oem', 'cross', 'interchange'].some(keyword => normalized.includes(keyword))) {
+    return 'oem';
+  }
+
+  if (normalized.includes('super')) {
+    return 'supersession';
+  }
+
+  if (['application', 'engine', 'model', 'guide'].some(keyword => normalized.includes(keyword))) {
+    return 'application';
+  }
+
+  return 'other';
+};
+
+export const useCrossMappings = () => {
+  const [entries, setEntries] = useState<CrossReferenceEntry[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchCrossReferences = async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      type Row = Database['public']['Tables']['cross_references']['Row'] & {
+        propeller: Pick<Database['public']['Tables']['propellers']['Row'], 'id' | 'model' | 'description'> | null;
+      };
+
+      const { data, error } = await supabase
+        .from('cross_references')
+        .select('id, reference_code, reference_type, competitor_model, notes, created_at, propeller:propellers ( id, model, description )');
+
+      if (error) {
+        throw error;
+      }
+
+      const normalized = ((data ?? []) as Row[]).map(row => {
+        const type = normalizeReferenceType(row.reference_type);
+        return {
+          id: row.id,
+          propellerId: row.propeller?.id ?? undefined,
+          cefCode: row.propeller?.model ?? row.reference_code,
+          referenceCode: row.reference_code,
+          context: row.competitor_model,
+          notes: row.notes,
+          rawType: row.reference_type,
+          type,
+          createdAt: row.created_at,
+        } satisfies CrossReferenceEntry;
+      });
+
+      setEntries(normalized);
+    } catch (err) {
+      console.error('Error loading cross references:', err);
+      setError('Impossibile caricare le equivalenze');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchCrossReferences();
+  }, []);
+
+  const oemInterchanges = useMemo<OemInterchange[]>(() => {
+    const map = new Map<string, { cefCode: string; propellerId?: string; manufacturers: Map<string, OemManufacturerGroup> }>();
+
+    entries
+      .filter(entry => entry.type === 'oem')
+      .forEach(entry => {
+        const key = entry.propellerId ?? entry.cefCode;
+        if (!map.has(key)) {
+          map.set(key, {
+            cefCode: entry.cefCode,
+            propellerId: entry.propellerId,
+            manufacturers: new Map(),
+          });
+        }
+
+        const record = map.get(key)!;
+        const manufacturerName = entry.context?.trim() || 'OEM';
+        const manufacturer = record.manufacturers.get(manufacturerName) ?? {
+          name: manufacturerName,
+          codes: [],
+          notes: [],
+        };
+
+        manufacturer.codes.push(entry.referenceCode);
+        if (entry.notes) {
+          manufacturer.notes.push(entry.notes);
+        }
+
+        record.manufacturers.set(manufacturerName, manufacturer);
+      });
+
+    return Array.from(map.values()).map(record => ({
+      cefCode: record.cefCode,
+      propellerId: record.propellerId,
+      manufacturers: Array.from(record.manufacturers.values()),
+    }));
+  }, [entries]);
+
+  const supersessions = useMemo<SupersessionChainEntry[]>(() => {
+    const map = new Map<string, SupersessionChainEntry>();
+
+    entries
+      .filter(entry => entry.type === 'supersession')
+      .forEach(entry => {
+        const key = entry.propellerId ?? entry.cefCode;
+        if (!map.has(key)) {
+          map.set(key, {
+            cefCode: entry.cefCode,
+            propellerId: entry.propellerId,
+            chain: [],
+          });
+        }
+
+        map.get(key)!.chain.push({
+          code: entry.referenceCode,
+          note: entry.notes,
+          createdAt: entry.createdAt,
+        });
+      });
+
+    return Array.from(map.values()).map(chain => ({
+      ...chain,
+      chain: chain.chain.sort((a, b) => {
+        if (a.createdAt && b.createdAt) {
+          return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+        }
+        return a.code.localeCompare(b.code);
+      })
+    }));
+  }, [entries]);
+
+  const applicationGuides = useMemo<ApplicationGuideEntry[]>(() => {
+    const map = new Map<string, ApplicationGuideEntry>();
+
+    entries
+      .filter(entry => entry.type === 'application')
+      .forEach(entry => {
+        const key = entry.propellerId ?? entry.cefCode;
+        if (!map.has(key)) {
+          map.set(key, {
+            cefCode: entry.cefCode,
+            propellerId: entry.propellerId,
+            applications: [],
+          });
+        }
+
+        map.get(key)!.applications.push({
+          model: entry.context ?? entry.referenceCode,
+          referenceCode: entry.referenceCode,
+          note: entry.notes,
+        });
+      });
+
+    return Array.from(map.values());
+  }, [entries]);
+
+  return {
+    entries,
+    isLoading,
+    error,
+    oemInterchanges,
+    supersessions,
+    applicationGuides,
+    refetch: fetchCrossReferences,
+  };
+};

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,16 +2,28 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://ucvlbtntemxmcovfmnka.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InVjdmxidG50ZW14bWNvdmZtbmthIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTc2Nzk5MTAsImV4cCI6MjA3MzI1NTkxMH0.lfvBdLeKfQyZGmELQCFwrDrxEOWW7Q16CrgM3bNjY9g";
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL ?? "https://ucvlbtntemxmcovfmnka.supabase.co";
+const SUPABASE_PUBLISHABLE_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY ??
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InVjdmxidG50ZW14bWNvdmZtbmthIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTc2Nzk5MTAsImV4cCI6MjA3MzI1NTkxMH0.lfvBdLeKfQyZGmELQCFwrDrxEOWW7Q16CrgM3bNjY9g";
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";
 
+const isBrowser = typeof window !== 'undefined';
+
+const authOptions = isBrowser
+  ? {
+      storage: window.localStorage,
+      persistSession: true,
+      autoRefreshToken: true,
+      detectSessionInUrl: true,
+    }
+  : {
+      persistSession: false,
+      autoRefreshToken: false,
+      detectSessionInUrl: false,
+    };
+
 export const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY, {
-  auth: {
-    storage: localStorage,
-    persistSession: true,
-    autoRefreshToken: true,
-  }
+  auth: authOptions,
 });


### PR DESCRIPTION
## Summary
- Harden toast subscription lifecycle and guard browser-only APIs in the sidebar context and Supabase client.
- Replace brittle search focus and navigation patterns in RFQ and Customers while reusing the shared search filter with refs.
- Build a Supabase-driven cross mapping experience with OEM, supersession and application views backed by a new hook.
- Streamline price list analytics queries and the Excel import workflow with batched lookups, reusable templates and progress feedback.

## Testing
- npm run lint *(fails: repository already contains numerous legacy lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cd15768888832a80a6c77eb416304f